### PR TITLE
Refactor client-server command structure and tests

### DIFF
--- a/ValidayClient/Network/Commands/ClientCommandBase.cs
+++ b/ValidayClient/Network/Commands/ClientCommandBase.cs
@@ -1,0 +1,44 @@
+using ValidayClient.Network.Commands.Interfaces;
+
+namespace ValidayClient.Network.Commands
+{
+    /// <summary>
+    /// Typed base class for incoming commands (server → client).
+    /// Subclasses define how to deserialize the packet into a payload object
+    /// and how to handle it — mirroring ServerCommandBase&lt;TPayload&gt; on the server.
+    /// </summary>
+    /// <typeparam name="TPayload">Type that carries the deserialized packet data.</typeparam>
+    /// <example>
+    /// <code>
+    /// public record ChatPayload(string Message);
+    ///
+    /// public class ChatCommand : ClientCommandBase&lt;ChatPayload&gt;
+    /// {
+    ///     protected override ChatPayload Read(PacketReader reader)
+    ///         => new ChatPayload(reader.ReadString());
+    ///
+    ///     protected override void Handle(ChatPayload payload)
+    ///         => Console.WriteLine(payload.Message);
+    /// }
+    /// </code>
+    /// </example>
+    public abstract class ClientCommandBase<TPayload> : IClientCommand
+    {
+        /// <inheritdoc/>
+        public void Execute(byte[] rawData)
+        {
+            PacketReader reader = new PacketReader(rawData).SkipCommandId();
+            TPayload payload = Read(reader);
+            Handle(payload);
+        }
+
+        /// <summary>
+        /// Deserializes the packet payload from <paramref name="reader"/>.
+        /// The command ID has already been skipped when this is called.
+        /// </summary>
+        protected abstract TPayload Read(PacketReader reader);
+
+        /// <summary>Processes the deserialized <paramref name="payload"/>.</summary>
+        protected abstract void Handle(TPayload payload);
+    }
+}

--- a/ValidayClient/Network/Commands/ServerCommandBase.cs
+++ b/ValidayClient/Network/Commands/ServerCommandBase.cs
@@ -1,0 +1,53 @@
+using ValidayClient.Network.Commands.Interfaces;
+
+namespace ValidayClient.Network.Commands
+{
+    /// <summary>
+    /// Base class for outgoing commands (client → server).
+    /// Subclasses write the payload into a <see cref="PacketWriter"/>
+    /// without worrying about command ID or byte layout.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// public class MoveCommand : ServerCommandBase
+    /// {
+    ///     public float X { get; set; }
+    ///     public float Y { get; set; }
+    ///
+    ///     public MoveCommand() : base(commandId: 2) { }
+    ///
+    ///     protected override void Write(PacketWriter writer)
+    ///     {
+    ///         writer.WriteFloat(X).WriteFloat(Y);
+    ///     }
+    /// }
+    ///
+    /// // Usage:
+    /// client.SendToServer(new MoveCommand { X = 10f, Y = 20f });
+    /// </code>
+    /// </example>
+    public abstract class ServerCommandBase : IServerCommand
+    {
+        private readonly ushort _commandId;
+
+        /// <param name="commandId">Command ID sent as the first 2 bytes of every packet.</param>
+        protected ServerCommandBase(ushort commandId)
+        {
+            _commandId = commandId;
+        }
+
+        /// <inheritdoc/>
+        public byte[] GetRawData()
+        {
+            PacketWriter writer = new PacketWriter(_commandId);
+            Write(writer);
+            return writer.Build();
+        }
+
+        /// <summary>
+        /// Writes the command payload into <paramref name="writer"/>.
+        /// The command ID is prepended automatically — do not write it here.
+        /// </summary>
+        protected abstract void Write(PacketWriter writer);
+    }
+}

--- a/ValidayClient/Network/PacketReader.cs
+++ b/ValidayClient/Network/PacketReader.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Text;
+
+namespace ValidayClient.Network
+{
+    /// <summary>
+    /// Sequential binary reader for incoming packets.
+    /// All multi-byte values are read in little-endian order.
+    /// </summary>
+    public sealed class PacketReader
+    {
+        /// <summary>Current read position within the buffer.</summary>
+        public int Position => _position;
+
+        /// <summary>Number of bytes not yet read.</summary>
+        public int Remaining => _data.Length - _position;
+
+        private readonly byte[] _data;
+        private int _position;
+
+        /// <summary>Creates a reader starting at position 0.</summary>
+        public PacketReader(byte[] data)
+        {
+            _data = data;
+            _position = 0;
+        }
+
+        /// <summary>Creates a reader starting at a given offset.</summary>
+        public PacketReader(byte[] data, int offset)
+        {
+            _data = data;
+            _position = offset;
+        }
+
+        /// <summary>
+        /// Advances past the 2-byte command ID at the start of the packet.
+        /// Returns <c>this</c> for fluent chaining.
+        /// </summary>
+        public PacketReader SkipCommandId()
+        {
+            _position += sizeof(ushort);
+            return this;
+        }
+
+        /// <summary>Advances the position by <paramref name="count"/> bytes.</summary>
+        public PacketReader Skip(int count)
+        {
+            _position += count;
+            return this;
+        }
+
+        /// <summary>Reads one byte.</summary>
+        public byte ReadByte() => _data[_position++];
+
+        /// <summary>Reads one byte as a boolean (0 = false, non-zero = true).</summary>
+        public bool ReadBool() => _data[_position++] != 0;
+
+        /// <summary>Reads a 2-byte signed integer.</summary>
+        public short ReadShort()
+        {
+            short value = BitConverter.ToInt16(_data, _position);
+            _position += sizeof(short);
+            return value;
+        }
+
+        /// <summary>Reads a 2-byte unsigned integer.</summary>
+        public ushort ReadUshort()
+        {
+            ushort value = BitConverter.ToUInt16(_data, _position);
+            _position += sizeof(ushort);
+            return value;
+        }
+
+        /// <summary>Reads a 4-byte signed integer.</summary>
+        public int ReadInt()
+        {
+            int value = BitConverter.ToInt32(_data, _position);
+            _position += sizeof(int);
+            return value;
+        }
+
+        /// <summary>Reads a 4-byte unsigned integer.</summary>
+        public uint ReadUint()
+        {
+            uint value = BitConverter.ToUInt32(_data, _position);
+            _position += sizeof(uint);
+            return value;
+        }
+
+        /// <summary>Reads an 8-byte signed integer.</summary>
+        public long ReadLong()
+        {
+            long value = BitConverter.ToInt64(_data, _position);
+            _position += sizeof(long);
+            return value;
+        }
+
+        /// <summary>Reads a 4-byte IEEE 754 float.</summary>
+        public float ReadFloat()
+        {
+            float value = BitConverter.ToSingle(_data, _position);
+            _position += sizeof(float);
+            return value;
+        }
+
+        /// <summary>Reads an 8-byte IEEE 754 double.</summary>
+        public double ReadDouble()
+        {
+            double value = BitConverter.ToDouble(_data, _position);
+            _position += sizeof(double);
+            return value;
+        }
+
+        /// <summary>
+        /// Reads a UTF-8 string prefixed by a 2-byte length header.
+        /// Format: [ushort byteCount][UTF-8 bytes]
+        /// </summary>
+        public string ReadString()
+        {
+            ushort length = ReadUshort();
+            string value = Encoding.UTF8.GetString(_data, _position, length);
+            _position += length;
+            return value;
+        }
+
+        /// <summary>Reads exactly <paramref name="count"/> raw bytes.</summary>
+        public byte[] ReadBytes(int count)
+        {
+            byte[] result = new byte[count];
+            Array.Copy(_data, _position, result, 0, count);
+            _position += count;
+            return result;
+        }
+
+        /// <summary>
+        /// Reads a byte array prefixed by a 2-byte length header.
+        /// Format: [ushort byteCount][bytes]
+        /// </summary>
+        public byte[] ReadBytesWithLength()
+        {
+            ushort length = ReadUshort();
+            return ReadBytes(length);
+        }
+    }
+}

--- a/ValidayClient/Network/PacketWriter.cs
+++ b/ValidayClient/Network/PacketWriter.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ValidayClient.Network
+{
+    /// <summary>
+    /// Fluent binary builder for outgoing packets.
+    /// All multi-byte values are written in little-endian order.
+    /// </summary>
+    public sealed class PacketWriter
+    {
+        private readonly ushort _commandId;
+        private readonly List<byte> _payload;
+
+        /// <param name="commandId">Command ID prepended to every built packet.</param>
+        public PacketWriter(ushort commandId)
+        {
+            _commandId = commandId;
+            _payload = new List<byte>();
+        }
+
+        /// <summary>Writes one byte.</summary>
+        public PacketWriter WriteByte(byte value)
+        {
+            _payload.Add(value);
+            return this;
+        }
+
+        /// <summary>Writes a boolean as one byte (true = 1, false = 0).</summary>
+        public PacketWriter WriteBool(bool value)
+        {
+            _payload.Add(value ? (byte)1 : (byte)0);
+            return this;
+        }
+
+        /// <summary>Writes a 2-byte signed integer.</summary>
+        public PacketWriter WriteShort(short value)
+        {
+            _payload.AddRange(BitConverter.GetBytes(value));
+            return this;
+        }
+
+        /// <summary>Writes a 2-byte unsigned integer.</summary>
+        public PacketWriter WriteUshort(ushort value)
+        {
+            _payload.AddRange(BitConverter.GetBytes(value));
+            return this;
+        }
+
+        /// <summary>Writes a 4-byte signed integer.</summary>
+        public PacketWriter WriteInt(int value)
+        {
+            _payload.AddRange(BitConverter.GetBytes(value));
+            return this;
+        }
+
+        /// <summary>Writes a 4-byte unsigned integer.</summary>
+        public PacketWriter WriteUint(uint value)
+        {
+            _payload.AddRange(BitConverter.GetBytes(value));
+            return this;
+        }
+
+        /// <summary>Writes an 8-byte signed integer.</summary>
+        public PacketWriter WriteLong(long value)
+        {
+            _payload.AddRange(BitConverter.GetBytes(value));
+            return this;
+        }
+
+        /// <summary>Writes a 4-byte IEEE 754 float.</summary>
+        public PacketWriter WriteFloat(float value)
+        {
+            _payload.AddRange(BitConverter.GetBytes(value));
+            return this;
+        }
+
+        /// <summary>Writes an 8-byte IEEE 754 double.</summary>
+        public PacketWriter WriteDouble(double value)
+        {
+            _payload.AddRange(BitConverter.GetBytes(value));
+            return this;
+        }
+
+        /// <summary>
+        /// Writes a UTF-8 string prefixed by a 2-byte length header.
+        /// Format: [ushort byteCount][UTF-8 bytes]
+        /// A null value is treated as an empty string.
+        /// </summary>
+        public PacketWriter WriteString(string? value)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(value ?? string.Empty);
+            _payload.AddRange(BitConverter.GetBytes((ushort)bytes.Length));
+            _payload.AddRange(bytes);
+            return this;
+        }
+
+        /// <summary>Writes raw bytes without a length prefix.</summary>
+        public PacketWriter WriteBytes(byte[] value)
+        {
+            _payload.AddRange(value);
+            return this;
+        }
+
+        /// <summary>
+        /// Writes raw bytes, optionally preceded by a 2-byte length header.
+        /// </summary>
+        public PacketWriter WriteBytes(byte[] value, bool lengthPrefixed)
+        {
+            if (lengthPrefixed)
+                _payload.AddRange(BitConverter.GetBytes((ushort)value.Length));
+
+            _payload.AddRange(value);
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the final packet without framing.
+        /// Format: [commandId : 2 bytes][payload]
+        /// </summary>
+        public byte[] Build()
+        {
+            byte[] result = new byte[sizeof(ushort) + _payload.Count];
+            BitConverter.GetBytes(_commandId).CopyTo(result, 0);
+            _payload.CopyTo(result, sizeof(ushort));
+            return result;
+        }
+
+        /// <summary>
+        /// Builds the final packet with a 2-byte length prefix.
+        /// Format: [bodyLength : 2 bytes][commandId : 2 bytes][payload]
+        /// Use this when the server is configured with LengthPrefixFramer.
+        /// </summary>
+        public byte[] BuildFramed()
+        {
+            byte[] body = Build();
+            byte[] framed = new byte[sizeof(ushort) + body.Length];
+            BitConverter.GetBytes((ushort)body.Length).CopyTo(framed, 0);
+            body.CopyTo(framed, sizeof(ushort));
+            return framed;
+        }
+    }
+}

--- a/ValidayClientTests/PacketTests.cs
+++ b/ValidayClientTests/PacketTests.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Text;
+using Xunit;
+using ValidayClient.Network;
+using ValidayClient.Network.Commands;
+using ValidayClient.Network.Commands.Interfaces;
+
+namespace ValidayClientTests
+{
+    public class PacketTests
+    {
+        // ── PacketWriter ────────────────────────────────────────────────────────
+
+        [Fact]
+        public void PacketWriter_Build_StartsWithCommandId()
+        {
+            byte[] data = new PacketWriter(42).Build();
+
+            Assert.Equal((ushort)42, BitConverter.ToUInt16(data, 0));
+        }
+
+        [Fact]
+        public void PacketWriter_Build_EmptyPayload_TwoBytes()
+        {
+            byte[] data = new PacketWriter(1).Build();
+
+            Assert.Equal(2, data.Length);
+        }
+
+        [Fact]
+        public void PacketWriter_BuildFramed_HasLengthPrefix()
+        {
+            byte[] data = new PacketWriter(1).WriteInt(99).BuildFramed();
+
+            ushort bodyLength = BitConverter.ToUInt16(data, 0);
+            Assert.Equal(data.Length - 2, bodyLength);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_Byte_RoundTrip()
+        {
+            byte[] data = new PacketWriter(1).WriteByte(200).Build();
+            byte result = new PacketReader(data).SkipCommandId().ReadByte();
+
+            Assert.Equal(200, result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_Bool_True_RoundTrip()
+        {
+            byte[] data = new PacketWriter(1).WriteBool(true).Build();
+            bool result = new PacketReader(data).SkipCommandId().ReadBool();
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_Bool_False_RoundTrip()
+        {
+            byte[] data = new PacketWriter(1).WriteBool(false).Build();
+            bool result = new PacketReader(data).SkipCommandId().ReadBool();
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_Short_RoundTrip()
+        {
+            byte[] data = new PacketWriter(1).WriteShort(-1234).Build();
+            short result = new PacketReader(data).SkipCommandId().ReadShort();
+
+            Assert.Equal((short)-1234, result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_Ushort_RoundTrip()
+        {
+            byte[] data = new PacketWriter(1).WriteUshort(60000).Build();
+            ushort result = new PacketReader(data).SkipCommandId().ReadUshort();
+
+            Assert.Equal((ushort)60000, result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_Int_RoundTrip()
+        {
+            byte[] data = new PacketWriter(1).WriteInt(-99999).Build();
+            int result = new PacketReader(data).SkipCommandId().ReadInt();
+
+            Assert.Equal(-99999, result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_Uint_RoundTrip()
+        {
+            byte[] data = new PacketWriter(1).WriteUint(3000000000u).Build();
+            uint result = new PacketReader(data).SkipCommandId().ReadUint();
+
+            Assert.Equal(3000000000u, result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_Long_RoundTrip()
+        {
+            byte[] data = new PacketWriter(1).WriteLong(long.MinValue).Build();
+            long result = new PacketReader(data).SkipCommandId().ReadLong();
+
+            Assert.Equal(long.MinValue, result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_Float_RoundTrip()
+        {
+            byte[] data = new PacketWriter(1).WriteFloat(3.14f).Build();
+            float result = new PacketReader(data).SkipCommandId().ReadFloat();
+
+            Assert.Equal(3.14f, result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_Double_RoundTrip()
+        {
+            byte[] data = new PacketWriter(1).WriteDouble(Math.PI).Build();
+            double result = new PacketReader(data).SkipCommandId().ReadDouble();
+
+            Assert.Equal(Math.PI, result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_String_RoundTrip()
+        {
+            byte[] data = new PacketWriter(1).WriteString("Hello, World!").Build();
+            string result = new PacketReader(data).SkipCommandId().ReadString();
+
+            Assert.Equal("Hello, World!", result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_String_Empty_RoundTrip()
+        {
+            byte[] data = new PacketWriter(1).WriteString(string.Empty).Build();
+            string result = new PacketReader(data).SkipCommandId().ReadString();
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_String_Null_TreatedAsEmpty()
+        {
+            byte[] data = new PacketWriter(1).WriteString(null).Build();
+            string result = new PacketReader(data).SkipCommandId().ReadString();
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_String_Unicode_RoundTrip()
+        {
+            const string text = "Привет, мир! 🌍";
+            byte[] data = new PacketWriter(1).WriteString(text).Build();
+            string result = new PacketReader(data).SkipCommandId().ReadString();
+
+            Assert.Equal(text, result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_Bytes_RoundTrip()
+        {
+            byte[] payload = { 10, 20, 30, 40 };
+            byte[] data = new PacketWriter(1).WriteBytes(payload).Build();
+            byte[] result = new PacketReader(data).SkipCommandId().ReadBytes(4);
+
+            Assert.Equal(payload, result);
+        }
+
+        [Fact]
+        public void PacketWriter_WriteRead_BytesWithLength_RoundTrip()
+        {
+            byte[] payload = { 5, 10, 15 };
+            byte[] data = new PacketWriter(1).WriteBytes(payload, lengthPrefixed: true).Build();
+            byte[] result = new PacketReader(data).SkipCommandId().ReadBytesWithLength();
+
+            Assert.Equal(payload, result);
+        }
+
+        [Fact]
+        public void PacketWriter_MultipleFields_CorrectOrder()
+        {
+            byte[] data = new PacketWriter(7)
+                .WriteInt(42)
+                .WriteString("hi")
+                .WriteBool(true)
+                .Build();
+
+            var reader = new PacketReader(data).SkipCommandId();
+
+            Assert.Equal(42, reader.ReadInt());
+            Assert.Equal("hi", reader.ReadString());
+            Assert.True(reader.ReadBool());
+        }
+
+        // ── PacketReader ────────────────────────────────────────────────────────
+
+        [Fact]
+        public void PacketReader_SkipCommandId_AdvancesBy2()
+        {
+            byte[] data = { 0x01, 0x00, 0xFF };
+            var reader = new PacketReader(data);
+            reader.SkipCommandId();
+
+            Assert.Equal(2, reader.Position);
+        }
+
+        [Fact]
+        public void PacketReader_Skip_AdvancesPosition()
+        {
+            byte[] data = new PacketWriter(1).WriteInt(0).WriteInt(99).Build();
+            var reader = new PacketReader(data).SkipCommandId().Skip(4);
+
+            Assert.Equal(99, reader.ReadInt());
+        }
+
+        [Fact]
+        public void PacketReader_Remaining_DecreasesOnRead()
+        {
+            byte[] data = new PacketWriter(1).WriteInt(0).Build();
+            var reader = new PacketReader(data).SkipCommandId();
+            int before = reader.Remaining;
+            reader.ReadInt();
+
+            Assert.Equal(before - 4, reader.Remaining);
+        }
+
+        [Fact]
+        public void PacketReader_Offset_Constructor_StartsAtOffset()
+        {
+            byte[] data = new PacketWriter(1).WriteByte(10).WriteByte(20).Build();
+            var reader = new PacketReader(data, offset: 3);
+
+            Assert.Equal(20, reader.ReadByte());
+        }
+
+        // ── ServerCommandBase ───────────────────────────────────────────────────
+
+        [Fact]
+        public void ServerCommandBase_GetRawData_ContainsCommandId()
+        {
+            var cmd = new SampleServerCommand(commandId: 5) { Value = 42 };
+            byte[] data = cmd.GetRawData();
+
+            Assert.Equal((ushort)5, BitConverter.ToUInt16(data, 0));
+        }
+
+        [Fact]
+        public void ServerCommandBase_GetRawData_ContainsPayload()
+        {
+            var cmd = new SampleServerCommand(commandId: 1) { Value = 99 };
+            byte[] data = cmd.GetRawData();
+            int value = BitConverter.ToInt32(data, 2);
+
+            Assert.Equal(99, value);
+        }
+
+        // ── ClientCommandBase ───────────────────────────────────────────────────
+
+        [Fact]
+        public void ClientCommandBase_Execute_DeserializesAndHandles()
+        {
+            byte[] data = new PacketWriter(3).WriteString("test").WriteInt(7).Build();
+            var cmd = new SampleClientCommand();
+
+            cmd.Execute(data);
+
+            Assert.Equal("test", cmd.LastMessage);
+            Assert.Equal(7, cmd.LastValue);
+        }
+
+        [Fact]
+        public void ClientCommandBase_Execute_SkipsCommandId()
+        {
+            byte[] data = new PacketWriter(99).WriteFloat(1.5f).Build();
+            var cmd = new FloatClientCommand();
+
+            cmd.Execute(data);
+
+            Assert.Equal(1.5f, cmd.LastValue);
+        }
+
+        // ── End-to-end: full packet lifecycle ───────────────────────────────────
+
+        [Fact]
+        public void FullLifecycle_ServerCommandBase_To_ClientCommandBase()
+        {
+            var outgoing = new ChatServerCommand { Message = "Hello", PlayerId = 42 };
+            byte[] wire = outgoing.GetRawData();
+
+            var incoming = new ChatClientCommand();
+            incoming.Execute(wire);
+
+            Assert.Equal("Hello", incoming.LastMessage);
+            Assert.Equal(42, incoming.LastPlayerId);
+        }
+
+        // ── Test helpers ────────────────────────────────────────────────────────
+
+        class SampleServerCommand : ServerCommandBase
+        {
+            public int Value { get; set; }
+            public SampleServerCommand(ushort commandId) : base(commandId) { }
+            protected override void Write(PacketWriter writer) => writer.WriteInt(Value);
+        }
+
+        record SamplePayload(string Message, int Value);
+
+        class SampleClientCommand : ClientCommandBase<SamplePayload>
+        {
+            public string LastMessage { get; private set; } = string.Empty;
+            public int LastValue { get; private set; }
+
+            protected override SamplePayload Read(PacketReader reader)
+                => new SamplePayload(reader.ReadString(), reader.ReadInt());
+
+            protected override void Handle(SamplePayload payload)
+            {
+                LastMessage = payload.Message;
+                LastValue = payload.Value;
+            }
+        }
+
+        class FloatClientCommand : ClientCommandBase<float>
+        {
+            public float LastValue { get; private set; }
+            protected override float Read(PacketReader reader) => reader.ReadFloat();
+            protected override void Handle(float payload) => LastValue = payload;
+        }
+
+        record ChatPayload(string Message, int PlayerId);
+
+        class ChatServerCommand : ServerCommandBase
+        {
+            public string Message { get; set; } = string.Empty;
+            public int PlayerId { get; set; }
+            public ChatServerCommand() : base(commandId: 10) { }
+            protected override void Write(PacketWriter writer)
+                => writer.WriteString(Message).WriteInt(PlayerId);
+        }
+
+        class ChatClientCommand : ClientCommandBase<ChatPayload>
+        {
+            public string LastMessage { get; private set; } = string.Empty;
+            public int LastPlayerId { get; private set; }
+
+            protected override ChatPayload Read(PacketReader reader)
+                => new ChatPayload(reader.ReadString(), reader.ReadInt());
+
+            protected override void Handle(ChatPayload payload)
+            {
+                LastMessage = payload.Message;
+                LastPlayerId = payload.PlayerId;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new base class system for commands in the client-server architecture. Commands received from the server now extend `ClientCommandBase<TPayload>`, while commands sent to the server extend `ServerCommandBase`, improving organization and payload handling.

The `README.md` has been updated with a quick start guide and examples reflecting these changes, including modifications to the `ChatMessageCommand` and `MoveCommand` classes.

A new section on packet format has been added to the `README.md`, detailing the layout used by `PacketWriter` and `PacketReader`.

Additionally, a new `PacketTests.cs` file has been created to include unit tests for the `PacketWriter` and `PacketReader` classes, ensuring correct functionality for various data types.

The `PacketReader` and `PacketWriter` classes have been implemented to facilitate reading and writing byte arrays, with methods for handling different data types in little-endian order.

Overall, these changes enhance the robustness and manageability of the client-server communication system.